### PR TITLE
3: setup backend as oauth resource server

### DIFF
--- a/backend-core/build.gradle.kts
+++ b/backend-core/build.gradle.kts
@@ -4,6 +4,8 @@ plugins {
     id("org.springframework.boot") version "3.4.4"
     id("io.spring.dependency-management") version "1.1.7"
     kotlin("plugin.jpa") version "1.9.25"
+    kotlin("plugin.serialization") version "2.1.20"
+    id("ch.acanda.gradle.fabrikt") version "1.14.0"
 }
 
 group = "net.moviepumpkins"
@@ -29,6 +31,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("javax.validation:validation-api:2.0.1.Final")
+    implementation("io.swagger.core.v3:swagger-annotations:2.2.29")
+    implementation("io.swagger.core.v3:swagger-models:2.2.29")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.liquibase:liquibase-core")
@@ -57,6 +62,43 @@ allOpen {
     annotation("jakarta.persistence.Embeddable")
 }
 
-tasks.withType<Test> {
-    useJUnitPlatform()
+sourceSets {
+    main {
+        java {
+            srcDir("${layout.buildDirectory.get()}/build/generated/sources/fabrikt")
+        }
+    }
+}
+
+fabrikt {
+    generate("core-api") {
+        apiFile = file("src/main/resources/core.api.yaml")
+        basePackage = "net.moviepumpkins.core.integration"
+        externalReferenceResolution = targeted
+        outputDirectory = file("build/generated/sources/fabrikt")
+        sourcesPath = "src/main/kotlin"
+        resourcesPath = "src/main/resources"
+        validationLibrary = Jakarta
+        typeOverrides {
+            datetime = OffsetDateTime
+            date = LocalDate
+        }
+        controller {
+            generate = enabled
+            target = Spring
+        }
+        model {
+            generate = enabled
+            extensibleEnums = disabled
+            serializationLibrary = Jackson
+            sealedInterfacesForOneOf = enabled
+        }
+    }
+}
+
+tasks {
+
+    withType<Test> {
+        useJUnitPlatform()
+    }
 }

--- a/backend-core/src/main/kotlin/net/moviepumpkins/core/config/AppConfig.kt
+++ b/backend-core/src/main/kotlin/net/moviepumpkins/core/config/AppConfig.kt
@@ -1,0 +1,28 @@
+package net.moviepumpkins.core.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.annotation.web.invoke
+import org.springframework.security.web.SecurityFilterChain
+
+@Configuration
+@EnableWebSecurity
+class AppConfig {
+    @Bean
+    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http {
+            authorizeHttpRequests {
+                authorize("/spec", permitAll)
+                authorize("/error", permitAll)
+                authorize(anyRequest, authenticated)
+            }
+
+            oauth2ResourceServer {
+                jwt { }
+            }
+        }
+        return http.build()
+    }
+}

--- a/backend-core/src/main/kotlin/net/moviepumpkins/core/config/GlobalExceptionHandler.kt
+++ b/backend-core/src/main/kotlin/net/moviepumpkins/core/config/GlobalExceptionHandler.kt
@@ -1,0 +1,7 @@
+package net.moviepumpkins.core.config
+
+import org.springframework.web.bind.annotation.ControllerAdvice
+
+@ControllerAdvice
+class GlobalExceptionHandler {
+}

--- a/backend-core/src/main/kotlin/net/moviepumpkins/core/config/ResponseValidationAdvice.kt
+++ b/backend-core/src/main/kotlin/net/moviepumpkins/core/config/ResponseValidationAdvice.kt
@@ -1,0 +1,38 @@
+package net.moviepumpkins.core.config
+
+import jakarta.validation.Validator
+import org.springframework.core.MethodParameter
+import org.springframework.http.MediaType
+import org.springframework.http.converter.HttpMessageConverter
+import org.springframework.http.server.ServerHttpRequest
+import org.springframework.http.server.ServerHttpResponse
+import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice
+
+@ControllerAdvice
+class ResponseValidationAdvice(
+    private val validator: Validator
+) : ResponseBodyAdvice<Any> {
+    override fun supports(returnType: MethodParameter, converterType: Class<out HttpMessageConverter<*>>): Boolean {
+        return true
+    }
+
+    override fun beforeBodyWrite(
+        body: Any?,
+        returnType: MethodParameter,
+        selectedContentType: MediaType,
+        selectedConverterType: Class<out HttpMessageConverter<*>>,
+        request: ServerHttpRequest,
+        response: ServerHttpResponse
+    ): Any? {
+        if (body != null) {
+            val violations = validator.validate(body)
+            if (violations.isNotEmpty()) {
+                throw ResponseValidationException(violations)
+            }
+        }
+
+        return body
+    }
+
+}

--- a/backend-core/src/main/kotlin/net/moviepumpkins/core/config/ResponseValidationException.kt
+++ b/backend-core/src/main/kotlin/net/moviepumpkins/core/config/ResponseValidationException.kt
@@ -1,0 +1,7 @@
+package net.moviepumpkins.core.config
+
+import jakarta.validation.ConstraintViolation
+
+class ResponseValidationException(
+    val constraintViolations: Set<ConstraintViolation<Any>>,
+) : IllegalStateException()

--- a/backend-core/src/main/kotlin/net/moviepumpkins/core/config/SchemaInit.kt
+++ b/backend-core/src/main/kotlin/net/moviepumpkins/core/config/SchemaInit.kt
@@ -2,7 +2,7 @@ package net.moviepumpkins.core.config
 
 import liquibase.change.DatabaseChange
 import liquibase.integration.spring.SpringLiquibase
-import net.moviepumpkins.core.extension.getLogger
+import net.moviepumpkins.core.general.getLogger
 import org.springframework.beans.factory.InitializingBean
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.AbstractDependsOnBeanFactoryPostProcessor

--- a/backend-core/src/main/kotlin/net/moviepumpkins/core/general/ExtensionsForLogging.kt
+++ b/backend-core/src/main/kotlin/net/moviepumpkins/core/general/ExtensionsForLogging.kt
@@ -1,4 +1,4 @@
-package net.moviepumpkins.core.extension
+package net.moviepumpkins.core.general
 
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory

--- a/backend-core/src/main/kotlin/net/moviepumpkins/core/integration/apispec/SpecController.kt
+++ b/backend-core/src/main/kotlin/net/moviepumpkins/core/integration/apispec/SpecController.kt
@@ -1,0 +1,25 @@
+package net.moviepumpkins.core.integration.apispec
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import jakarta.validation.Valid
+import net.moviepumpkins.core.integration.controllers.SpecController
+import net.moviepumpkins.core.integration.models.Specification
+import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@Validated
+class SpecController(
+    private val objectMapper: ObjectMapper,
+) : SpecController {
+
+    @Valid
+    override fun get(): ResponseEntity<Specification> {
+        val specification =
+            objectMapper.readValue<Specification>(javaClass.classLoader.getResource("config/spec.response.json"))
+        return ResponseEntity.ok(specification)
+    }
+
+}

--- a/backend-core/src/main/resources/application-dev.yaml
+++ b/backend-core/src/main/resources/application-dev.yaml
@@ -1,6 +1,3 @@
-logging:
-  file:
-    name:
 spring:
   jpa:
     show-sql: true
@@ -11,3 +8,8 @@ spring:
     url: jdbc:postgresql://localhost:5432/pumpkins
     username: admin
     password: gYLWLbQUcY
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: http://localhost:9090/realms/moviepumpkins

--- a/backend-core/src/main/resources/config/spec.response.json
+++ b/backend-core/src/main/resources/config/spec.response.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0.0",
+  "apiTitle": "net.moviepumpkins.core",
+  "license": {
+    "name": "Apache 2.0",
+    "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+  }
+}

--- a/backend-core/src/main/resources/core.api.yaml
+++ b/backend-core/src/main/resources/core.api.yaml
@@ -1,0 +1,43 @@
+openapi: 3.0.2
+info:
+  version: '1.0.0'
+  title: net.moviepumpkins.core
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+
+paths:
+  '/spec':
+    get:
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Specification'
+
+components:
+  schemas:
+    Specification:
+      type: object
+      required:
+        - version
+        - license
+        - apiTitle
+      properties:
+        version:
+          type: string
+          pattern: '\d+\.\d+\.\d+'
+        license:
+          type: object
+          required:
+            - name
+            - url
+          properties:
+            name:
+              type: string
+            url:
+              type: string
+        apiTitle:
+          type: string

--- a/compose.yaml
+++ b/compose.yaml
@@ -14,7 +14,7 @@ services:
   pgadmin:
     image: dpage/pgadmin4:2
     container_name: pgadmin4_container
-    restart: on-failure
+    restart: no
     ports:
       - "8888:80"
     environment:
@@ -22,6 +22,31 @@ services:
       PGADMIN_DEFAULT_PASSWORD: gYLWLbQUcY
     volumes:
       - pgadmin_data:/var/lib/pgadmin
+  keycloak:
+    image: quay.io/keycloak/keycloak:23.0.7
+    container_name: keycloak_container
+    environment:
+      KC_DB: postgres
+      KC_DB_URL: jdbc:postgresql://db:5432/pumpkins
+      KC_DB_USERNAME: admin
+      KC_DB_PASSWORD: gYLWLbQUcY
+
+      KC_HOSTNAME: localhost
+      KC_HOSTNAME_PORT: 9090
+      KC_HOSTNAME_STRICT: false
+      KC_HOSTNAME_STRICT_HTTPS: false
+
+      KC_LOG_LEVEL: info
+      KC_METRICS_ENABLED: true
+      KC_HEALTH_ENABLED: true
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: gaO1xZDFl5
+    command: start-dev
+    depends_on:
+      - db
+    ports:
+      - "9090:8080"
+
 
 volumes:
   pg_data:

--- a/requests.http.template
+++ b/requests.http.template
@@ -1,0 +1,5 @@
+@base_address = http://localhost:8080
+@token =
+
+GET {{base_address}}/spec
+Accept: application/json


### PR DESCRIPTION
- configured keycloak
- set it up as authorization server for spring backend
- added open api generation
- responses throw an error if they don't comply with validation
- added example endpoint (/spec)
- added requests.http.template for manual testing